### PR TITLE
Fix snapshot cache busting and add live update harness

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,129 +32,129 @@ func NewServer(r *repo.Repo, env, adminKey string) *Server {
 }
 
 func (s *Server) Router() http.Handler {
-    // inside (s *Server) Router():
+	// inside (s *Server) Router():
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID, middleware.RealIP, middleware.Recoverer)
 	r.Use(telemetry.Middleware)
 
 	// CORS for browser clients (adjust origins as needed)
 	r.Use(cors.Handler(cors.Options{
-  	AllowedOrigins:   []string{"http://localhost:3000", "http://localhost:5173", "http://localhost:8080"},
-  	AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
-  	AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
-  	ExposedHeaders:   []string{"ETag"},
-  	AllowCredentials: false,
-  	MaxAge:           300,
+		AllowedOrigins:   []string{"http://localhost:3000", "http://localhost:5173", "http://localhost:8080"},
+		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		ExposedHeaders:   []string{"ETag"},
+		AllowCredentials: false,
+		MaxAge:           300,
 	}))
 
 	// Normal routes with timeout + rate limit
 	r.Group(func(r chi.Router) {
-	r.Use(middleware.Timeout(5 * time.Second))
-	r.Use(httprate.LimitByIP(100, time.Minute)) // 100 req/min per IP
+		r.Use(middleware.Timeout(5 * time.Second))
+		r.Use(httprate.LimitByIP(100, time.Minute)) // 100 req/min per IP
 
-	r.Get("/healthz", s.handleHealth)
-	r.Get("/v1/flags/snapshot", s.handleSnapshot)
-	r.Post("/v1/flags", s.authAdmin(s.handleUpsertFlag))
+		r.Get("/healthz", s.handleHealth)
+		r.Get("/v1/flags/snapshot", s.handleSnapshot)
+		r.Post("/v1/flags", s.authAdmin(s.handleUpsertFlag))
 	})
 
 	// SSE route: no timeout, but optional gentle rate limit on connects
 	r.Group(func(r chi.Router) {
-	r.Use(httprate.LimitByIP(30, time.Minute)) // 30 connects/min per IP
-	r.Get("/v1/flags/stream", s.handleStream)
+		r.Use(httprate.LimitByIP(30, time.Minute)) // 30 connects/min per IP
+		r.Get("/v1/flags/stream", s.handleStream)
 	})
 
-return r
+	return r
 }
-
 
 func (s *Server) handleSnapshot(w http.ResponseWriter, req *http.Request) {
-    snap := snapshot.Load()
-    if inm := req.Header.Get("If-None-Match"); inm != "" && inm == snap.ETag {
-        w.WriteHeader(http.StatusNotModified)
-        return
-    }
-    w.Header().Set("Content-Type", "application/json")
-    w.Header().Set("ETag", snap.ETag)
-    _ = json.NewEncoder(w).Encode(snap)
+	snap := snapshot.Load()
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+	w.Header().Set("ETag", snap.ETag)
+
+	if inm := req.Header.Get("If-None-Match"); inm != "" && inm == snap.ETag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(snap)
 }
 
-
 func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
-    // Proper headers
-    w.Header().Set("Content-Type", "text/event-stream")
-    w.Header().Set("Cache-Control", "no-cache")
-    w.Header().Set("Connection", "keep-alive")
-    w.Header().Set("Access-Control-Allow-Origin", "*")
+	// Proper headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-    // Check flusher
-    flusher, ok := w.(http.Flusher)
-    if !ok {
-        http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
-        return
-    }
+	// Check flusher
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
 
-    // Subscribe to updates
-    updates, unsubscribe := snapshot.Subscribe()
-    defer unsubscribe()
+	// Subscribe to updates
+	updates, unsubscribe := snapshot.Subscribe()
+	defer unsubscribe()
 
-    // Send init immediately
-    snap := snapshot.Load()
-    writeSSE(w, "init", map[string]string{"etag": snap.ETag})
-    flusher.Flush()
+	// Send init immediately
+	snap := snapshot.Load()
+	writeSSE(w, "init", map[string]string{"etag": snap.ETag})
+	flusher.Flush()
 
-    ticker := time.NewTicker(25 * time.Second)
-    defer ticker.Stop()
+	ticker := time.NewTicker(25 * time.Second)
+	defer ticker.Stop()
 
-    ctx := r.Context()
-    for {
-        select {
-        case etag, ok := <-updates:
-            if !ok {
-                return
-            }
-            writeSSE(w, "update", map[string]string{"etag": etag})
-            flusher.Flush()
+	ctx := r.Context()
+	for {
+		select {
+		case etag, ok := <-updates:
+			if !ok {
+				return
+			}
+			writeSSE(w, "update", map[string]string{"etag": etag})
+			flusher.Flush()
 
-        case <-ticker.C:
-            fmt.Fprint(w, ": ping\n\n")
-            flusher.Flush()
+		case <-ticker.C:
+			fmt.Fprint(w, ": ping\n\n")
+			flusher.Flush()
 
-        case <-ctx.Done():
-            return
-        }
-    }
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func writeSSE(w http.ResponseWriter, event string, data any) {
-    w.Write([]byte("event: " + event + "\n"))
-    json.NewEncoder(w).Encode(map[string]any{"data": data})
-    w.Write([]byte("\n"))
+	w.Write([]byte("event: " + event + "\n"))
+	json.NewEncoder(w).Encode(map[string]any{"data": data})
+	w.Write([]byte("\n"))
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
-    w.WriteHeader(http.StatusOK)
-    _, _ = w.Write([]byte("ok"))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
 }
-
-
 
 // ---- handlers ----
 
 type upsertRequest struct {
-	Key         string                 `json:"key"`
-	Description string                 `json:"description"`
-	Enabled     bool                   `json:"enabled"`
-	Rollout     int32                  `json:"rollout"`
-	Expression  *string                `json:"expression,omitempty"`
-	Config      map[string]any         `json:"config,omitempty"`
-	Env         *string                `json:"env,omitempty"` // defaults to s.env
+	Key         string         `json:"key"`
+	Description string         `json:"description"`
+	Enabled     bool           `json:"enabled"`
+	Rollout     int32          `json:"rollout"`
+	Expression  *string        `json:"expression,omitempty"`
+	Config      map[string]any `json:"config,omitempty"`
+	Env         *string        `json:"env,omitempty"` // defaults to s.env
 }
 
 type upsertResponse struct {
 	OK   bool   `json:"ok"`
 	ETag string `json:"etag"`
 }
-
 
 func (s *Server) handleUpsertFlag(w http.ResponseWriter, r *http.Request) {
 	var req upsertRequest
@@ -194,13 +194,13 @@ func (s *Server) handleUpsertFlag(w http.ResponseWriter, r *http.Request) {
 
 	// upsert via sqlc
 	params := dbgen.UpsertFlagParams{
-		Key:        req.Key,
+		Key:         req.Key,
 		Description: pgtype.Text{String: req.Description, Valid: true},
-		Enabled:    req.Enabled,
-		Rollout:    req.Rollout,
-		Expression: req.Expression, // *string ok
-		Config:     cfgBytes,       // []byte
-		Env:        env,
+		Enabled:     req.Enabled,
+		Rollout:     req.Rollout,
+		Expression:  req.Expression, // *string ok
+		Config:      cfgBytes,       // []byte
+		Env:         env,
 	}
 	if err := s.repo.UpsertFlag(r.Context(), params); err != nil {
 		writeError(w, http.StatusInternalServerError, "db upsert failed")

--- a/scripts/live-update.ps1
+++ b/scripts/live-update.ps1
@@ -1,0 +1,58 @@
+param(
+    [string]$ApiBase = 'http://localhost:8080',
+    [string]$AdminKey = 'admin-123',
+    [string]$FlagKey = 'checkout_new_ui'
+)
+
+function Invoke-Json {
+    param(
+        [string]$Method,
+        [string]$Url,
+        [hashtable]$Headers,
+        [string]$Body
+    )
+
+    try {
+        return Invoke-WebRequest -Method $Method -Uri $Url -Headers $Headers -Body $Body -ContentType 'application/json'
+    }
+    catch {
+        Write-Error "Request to $Url failed: $($_.Exception.Message)"
+        if ($_.Exception.Response -and $_.Exception.Response.Content) {
+            Write-Error ([System.Text.Encoding]::UTF8.GetString($_.Exception.Response.Content))
+        }
+        throw
+    }
+}
+
+Write-Host "Fetching current snapshot from $ApiBase..."
+$snapshot = Invoke-Json -Method 'GET' -Url "$ApiBase/v1/flags/snapshot?ts=$(Get-Random)" -Headers @{}
+$oldEtag = $snapshot.Headers.ETag
+Write-Host "Current ETag: $oldEtag"
+
+$timestamp = [DateTime]::UtcNow.ToString('o')
+$payload = @{
+    key = $FlagKey
+    description = "updated $timestamp"
+    enabled = $true
+    rollout = 50
+    config = @{ variant = $timestamp }
+    env = 'prod'
+} | ConvertTo-Json -Depth 4
+
+Write-Host "Posting flag update..."
+$headers = @{ Authorization = "Bearer $AdminKey" }
+Invoke-Json -Method 'POST' -Url "$ApiBase/v1/flags" -Headers $headers -Body $payload | Out-Null
+
+Write-Host "Re-fetching snapshot with If-None-Match: $oldEtag"
+$newHeaders = @{ 'If-None-Match' = $oldEtag }
+$newSnapshot = Invoke-Json -Method 'GET' -Url "$ApiBase/v1/flags/snapshot?ts=$(Get-Random)" -Headers $newHeaders
+$newEtag = $newSnapshot.Headers.ETag
+Write-Host "New ETag: $newEtag"
+
+if ($newEtag -eq $oldEtag) {
+    Write-Warning 'ETag did not change; snapshot may be stale.'
+} else {
+    Write-Host 'Snapshot updated successfully.'
+}
+
+$newSnapshot.Content | Write-Output

--- a/sdk/dist/flagshipClient.d.ts
+++ b/sdk/dist/flagshipClient.d.ts
@@ -33,6 +33,8 @@ export declare class FlagshipClient {
     private refresh;
     private openStream;
     private refreshWithETag;
+    private snapshotUrl;
+    private fetchSnapshot;
     private scheduleReconnect;
     private emit;
 }

--- a/sdk/dist/flagshipClient.js
+++ b/sdk/dist/flagshipClient.js
@@ -56,16 +56,7 @@ export class FlagshipClient {
     }
     // ---- internals ----
     async refresh() {
-        const url = `${this.base}/v1/flags/snapshot`;
-        const headers = {};
-        if (this.cache?.etag)
-            headers['If-None-Match'] = this.cache.etag;
-        const res = await this.fetch(url, { headers });
-        if (res.status === 304)
-            return; // nothing changed
-        if (!res.ok)
-            throw new Error(`snapshot ${res.status}`);
-        this.cache = await res.json();
+        await this.fetchSnapshot();
     }
     openStream() {
         if (!this.ES) {
@@ -89,12 +80,16 @@ export class FlagshipClient {
         es.addEventListener('update', async (e) => {
             try {
                 const { etag } = JSON.parse(e.data);
-                if (etag && etag !== this.cache?.etag) {
-                    const changed = await this.refreshWithETag(etag);
-                    if (changed) {
-                        this.emit('update', etag);
-                    }
+                if (!etag) {
+                    return;
                 }
+                if (etag === this.cache?.etag) {
+                    const currentEtag = this.cache?.etag ?? etag;
+                    this.emit('update', currentEtag);
+                    return;
+                }
+                const changed = await this.refreshWithETag(etag);
+                this.emit('update', this.cache?.etag ?? etag);
             }
             catch (err) {
                 this.emit('error', err);
@@ -111,17 +106,31 @@ export class FlagshipClient {
     async refreshWithETag(etag) {
         if (!etag)
             return false;
-        // Ask the server only if our local copy is stale
-        const url = `${this.base}/v1/flags/snapshot`;
+        const changed = await this.fetchSnapshot();
+        return changed;
+    }
+    snapshotUrl() {
+        const base = this.base.endsWith('/') ? this.base : `${this.base}/`;
+        const url = new URL(`${base}v1/flags/snapshot`);
+        url.searchParams.set('ts', Date.now().toString());
+        return url.toString();
+    }
+    async fetchSnapshot() {
+        const url = this.snapshotUrl();
         const headers = {};
-        if (this.cache?.etag)
+        if (this.cache?.etag) {
             headers['If-None-Match'] = this.cache.etag;
-        const res = await this.fetch(url, { headers });
+        }
+        const res = await this.fetch(url, {
+            headers,
+            cache: 'no-store',
+        });
         if (res.status === 304) {
             return false;
         }
-        if (!res.ok)
+        if (!res.ok) {
             throw new Error(`snapshot ${res.status}`);
+        }
         const next = (await res.json());
         this.cache = next;
         return true;

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "tsc -p ."
+    "build": "tsc -p .",
+    "test": "node ./tests/live-update.spec.js"
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/sdk/tests/live-update.spec.js
+++ b/sdk/tests/live-update.spec.js
@@ -1,0 +1,267 @@
+import { FlagshipClient } from '../dist/flagshipClient.js';
+
+class MessageEventShim {
+  constructor(type, data) {
+    this.type = type;
+    this.data = data;
+  }
+}
+
+class HeadlessEventSource {
+  #url;
+  #listeners = new Map();
+  #controller = new AbortController();
+  onerror = null;
+
+  constructor(url) {
+    this.#url = url;
+    this.#start();
+  }
+
+  async #start() {
+    try {
+      const res = await fetch(this.#url, {
+        cache: 'no-store',
+        headers: {
+          Accept: 'text/event-stream',
+        },
+        signal: this.#controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        throw new Error(`SSE connect failed: ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          buffer += decoder.decode();
+          if (buffer.trim().length > 0) {
+            this.#processEvent(buffer);
+          }
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+
+        let idx;
+        while ((idx = buffer.indexOf('\n\n')) !== -1) {
+          const chunk = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+          if (chunk.trim().length === 0) continue;
+          this.#processEvent(chunk);
+        }
+      }
+    } catch (err) {
+      if (err && err.name === 'AbortError') {
+        return;
+      }
+      if (typeof this.onerror === 'function') {
+        this.onerror(err);
+      }
+    }
+  }
+
+  #processEvent(raw) {
+    const lines = raw.split(/\r?\n/);
+    let eventName = 'message';
+    const payloadLines = [];
+
+    for (const line of lines) {
+      if (!line) continue;
+      if (line.startsWith('event:')) {
+        eventName = line.slice(6).trim() || 'message';
+        continue;
+      }
+      if (line.startsWith('data:')) {
+        payloadLines.push(line.slice(5).trim());
+        continue;
+      }
+      payloadLines.push(line.trim());
+    }
+
+    const joined = payloadLines.join('\n');
+    let parsed = joined;
+    try {
+      const candidate = JSON.parse(joined);
+      parsed = candidate?.data ?? candidate;
+    } catch {
+      // fall back to raw string
+    }
+
+    const data = typeof parsed === 'string' ? parsed : JSON.stringify(parsed);
+    this.#dispatch(eventName, new MessageEventShim(eventName, data));
+  }
+
+  #dispatch(type, event) {
+    const listeners = this.#listeners.get(type);
+    if (!listeners) return;
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+
+  addEventListener(type, listener) {
+    const set = this.#listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.#listeners.set(type, set);
+  }
+
+  removeEventListener(type, listener) {
+    const set = this.#listeners.get(type);
+    if (!set) return;
+    set.delete(listener);
+    if (set.size === 0) {
+      this.#listeners.delete(type);
+    }
+  }
+
+  close() {
+    this.#controller.abort();
+    this.#listeners.clear();
+  }
+}
+
+class HeadlessPage {
+  #baseUrl;
+  #pendingUpdate = null;
+  #pendingTimer = null;
+  outText = '';
+
+  constructor(baseUrl) {
+    this.#baseUrl = baseUrl;
+    this.client = new FlagshipClient({
+      baseUrl,
+      eventSourceImpl: HeadlessEventSource,
+    });
+
+    this.client.on('ready', () => {
+      this.#render();
+    });
+
+    this.client.on('update', () => {
+      this.#render();
+      if (this.#pendingUpdate) {
+        const resolve = this.#pendingUpdate;
+        this.#pendingUpdate = null;
+        if (this.#pendingTimer) {
+          clearTimeout(this.#pendingTimer);
+          this.#pendingTimer = null;
+        }
+        resolve();
+      }
+    });
+
+    this.client.on('error', (err) => {
+      console.error('[HeadlessPage] SDK error:', err);
+    });
+  }
+
+  async init() {
+    await this.client.init();
+    this.#render();
+  }
+
+  #render() {
+    const flags = this.client.keys().map((key) => ({
+      key,
+      enabled: this.client.isEnabled(key),
+      config: this.client.getConfig(key),
+    }));
+    const snapshot = {
+      etag: this.client['cache']?.etag ?? null,
+      flags,
+    };
+    this.outText = JSON.stringify(snapshot, null, 2);
+  }
+
+  currentEtag() {
+    return this.client['cache']?.etag ?? null;
+  }
+
+  waitForNextUpdate(timeoutMs = 7000) {
+    if (this.#pendingUpdate) {
+      throw new Error('waitForNextUpdate already pending');
+    }
+    return new Promise((resolve, reject) => {
+      this.#pendingUpdate = resolve;
+      const timer = setTimeout(() => {
+        this.#pendingUpdate = null;
+        this.#pendingTimer = null;
+        reject(new Error('Timed out waiting for update'));
+      }, timeoutMs);
+      if (typeof timer === 'object' && typeof timer.unref === 'function') {
+        timer.unref();
+      }
+      this.#pendingTimer = timer;
+    });
+  }
+
+  dispose() {
+    this.client.close();
+    if (this.#pendingTimer) {
+      clearTimeout(this.#pendingTimer);
+      this.#pendingTimer = null;
+    }
+  }
+}
+
+async function run() {
+  const baseUrl = process.env.FLAGSHIP_BASE_URL ?? 'http://localhost:8080';
+  const adminKey = process.env.FLAGSHIP_ADMIN_KEY ?? 'admin-123';
+  const flagKey = process.env.FLAGSHIP_FLAG_KEY ?? 'checkout_new_ui';
+
+  const page = new HeadlessPage(baseUrl);
+  try {
+    await page.init();
+    const beforeEtag = page.currentEtag();
+
+    const unique = `${Date.now()}`;
+    const payload = {
+      key: flagKey,
+      description: `updated ${unique}`,
+      enabled: true,
+      rollout: 50,
+      config: { variant: unique },
+      env: 'prod',
+    };
+
+    const updatePromise = page.waitForNextUpdate();
+
+    const res = await fetch(`${baseUrl}/v1/flags`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${adminKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Flag update failed: ${res.status} ${text}`);
+    }
+
+    await updatePromise;
+    const afterEtag = page.currentEtag();
+
+    if (!afterEtag || afterEtag === beforeEtag) {
+      throw new Error(`Expected ETag to change (before=${beforeEtag}, after=${afterEtag})`);
+    }
+
+    console.log('✅ Live update detected. New ETag:', afterEtag);
+    console.log('Rendered snapshot:\n', page.outText);
+  } finally {
+    page.dispose();
+  }
+}
+
+if (import.meta.url === (process.argv[1] && new URL(`file://${process.argv[1]}`).href)) {
+  run().catch((err) => {
+    console.error('Live update harness failed:', err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- ensure the snapshot handler sets no-cache headers and still returns the current ETag on 304 responses
- force the browser SDK to bypass caches on SSE updates and always notify listeners with the latest ETag
- add a headless live-update harness plus a PowerShell helper script for manual verification

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69035cb7dec08328a250a06aee23ae47